### PR TITLE
BaseUrl and Nsfw support, and bugfixes

### DIFF
--- a/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
@@ -11,10 +11,13 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import mu.KotlinLogging
 import suwayomi.tachidesk.manga.impl.extension.Extension.installAPK
 import java.io.File
 
 object InspectorMain {
+    private val logger = KotlinLogging.logger {}
+
     suspend fun inspectorMain(args: Array<String>) {
         if (args.size < 3) {
             throw RuntimeException("Inspector must be given the path of apks directory, output json, and a tmp dir")
@@ -27,7 +30,7 @@ object InspectorMain {
         val tmpDir = File(tmpDirPath, "tmp").also { it.mkdir() }
         val extensions = File(apksPath).listFiles().orEmpty().mapNotNull {
             if (it.extension == "apk") {
-                println("Installing ${it.absolutePath}")
+                logger.info("Installing ${it.absolutePath}")
 
                 val (pkgName, sources) = installAPK(tmpDir) {
                     it

--- a/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
@@ -7,11 +7,11 @@ package suwayomi.tachidesk
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import eu.kanade.tachiyomi.source.CatalogueSource
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import mu.KotlinLogging
+import suwayomi.tachidesk.manga.impl.extension.Extension
 import suwayomi.tachidesk.manga.impl.extension.Extension.installAPK
 import java.io.File
 
@@ -46,9 +46,17 @@ object InspectorMain {
     data class SourceJson(
         val name: String,
         val lang: String,
-        val id: String
+        val id: String,
+        val baseUrl: String,
+        val nsfw: Boolean
     ) {
-        constructor(source: CatalogueSource) :
-            this(source.name, source.lang, source.id.toString())
+        constructor(loadedSource: Extension.LoadedSource) :
+            this(
+                loadedSource.source.name,
+                loadedSource.source.lang,
+                loadedSource.source.id.toString(),
+                loadedSource.source.baseUrl,
+                loadedSource.isNsfw
+            )
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/InspectorMain.kt
@@ -46,9 +46,9 @@ object InspectorMain {
     data class SourceJson(
         val name: String,
         val lang: String,
-        val id: Long
+        val id: String
     ) {
         constructor(source: CatalogueSource) :
-            this(source.name, source.lang, source.id)
+            this(source.name, source.lang, source.id.toString())
     }
 }

--- a/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
+++ b/server/src/main/kotlin/suwayomi/tachidesk/manga/impl/util/PackageTools.kt
@@ -90,7 +90,7 @@ object PackageTools {
                 dBuilder.parse(it)
             }
 
-            logger.debug(parsed.manifestXml)
+            logger.trace(parsed.manifestXml)
 
             applicationInfo.metaData = Bundle().apply {
                 val appTag = doc.getElementsByTagName("application").item(0)


### PR DESCRIPTION
- Adds support for getting the baseUrl field and the Nsfw annotation and adding them into the source Json
- Enhance and fix logging
- Fixes rounding errors when jq tries to parse a Long value as a number, it is now a string that Json parsers can decode to a long if required